### PR TITLE
fix: child pipeline URL modification

### DIFF
--- a/parent/screwdriver.yaml
+++ b/parent/screwdriver.yaml
@@ -1,6 +1,6 @@
 childPipelines:
   scmUrls:
-    - git@github.com:yk634/functional-sd-setup-scm.git#master:child
+    - git@github.com:screwdriver-cd-test/functional-sd-setup-scm.git#master:child
 
 shared:
   image: node:18


### PR DESCRIPTION
The URL of the child pipeline was still in the personal organization for verification, so this will be corrected.